### PR TITLE
Fix PASERK string lengths in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,14 +190,14 @@ The PASETO spec dictates that you use Ed25519 keys, which are 64 bytes long. To 
 
 Type | Expected format | Length
 -------------|------------------------------------------------------------------|-----------------
-`PASERK`     | `k4.secret.[key data as base64url]`                              | 52 characters
+`PASERK`     | `k4.secret.[key data as base64url]`                              | 96 characters
 `Uint8Array` | `[0x6b, 0x34, 0x2e, 0x73, 0x65, 0x63, 0x72, 0x65, 0x74, ...key]` | 41 bytes
 
 ### Public key format
 
 Type         | Expected format                                                  | Length
 -------------|------------------------------------------------------------------|---------------
-`PASERK`     | `k4.public.[key data as base64url]`                              | 52 characters
+`PASERK`     | `k4.public.[key data as base64url]`                              | 53 characters
 `Uint8Array` | `[0x6b, 0x34, 0x2e, 0x70, 0x75, 0x62, 0x6c, 0x69, 0x63, ...key]` | 41 bytes
 
 #### Generate a secret/public key pair


### PR DESCRIPTION
The string lengths in the README don't seem correct.

Examples from the spec:

```
> strlen("k4.public.cHFyc3R1dnd4eXp7fH1-f4CBgoOEhYaHiImKi4yNjo8")
= 53

> strlen("k4.secret.cHFyc3R1dnd4eXp7fH1-f4CBgoOEhYaHiImKi4yNjo8c5WpIyC_5kWKhS8VEYSZ05dYfuTF-ZdQFV4D9vLTcNQ")
= 96
```

Reference:
- https://github.com/paseto-standard/paserk/blob/master/types/secret.md
- https://github.com/paseto-standard/paserk/blob/master/types/public.md

The `Uint8Array` byte sizes should probably be adjusted too, but I'm not sure how to verify this.