### PR TITLE
`nbf` should be allowed to be equal to `iat`

### DIFF
--- a/src/lib/parse.ts
+++ b/src/lib/parse.ts
@@ -289,7 +289,7 @@ export function parsePayload(payload: string | Payload | Uint8Array, {
             throw new PasetoClaimInvalid("Payload must have a valid \"nbf\" claim (is not an date or a valid relative time string (e.g. \"1 hour\"))");
         }
         // The "nbf" claim must be greater than the "iat" claim
-        if (obj.hasOwnProperty("iat") && nbf <= Date.parse((obj as any).iat)) {
+        if (obj.hasOwnProperty("iat") && nbf < Date.parse((obj as any).iat)) {
             throw new PasetoClaimInvalid("Payload must have a valid \"nbf\" claim (is not greater than \"iat\")");
         }
         // The "nbf" claim must not be in the future


### PR DESCRIPTION
I have a PASETO with a payload like this:

```
..."iat":"2024-03-07T13:15:41-05:00","nbf":"2024-03-07T13:15:41-05:00"...
```

The `iat` and `nbf` claims are the same, but I get an error when validating:

```
Payload must have a valid "nbf" claim (is not greater than "iat")
```

I think this is incorrect, the condition should allow equal values.

Arguably an equal `nbf` doesn't serve much value, but the error is surprising regardless.

I didn't add a test cause I just did this change via GitHub UI without checking out the repo. I figure a simple test should be added to cover this case.