### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ try {
         }
     );
 
-    // payload: { sub: '1234567890', name: 'John Doe', iat: "2023-01-01T00:00:00.000Z" }
+    // payload: { sub: '1234567890', name: 'John Doe', iat: "2023-01-01T00:00:00.000Z", foo: 'bar' }
     // footer: { kid: 'xxx..', wpk: 'xxx..' }
 
 } catch(err) {


### PR DESCRIPTION
Added missing `foo` claim in the payload comment for the sample code on [Decrypt a token](https://github.com/auth70/paseto-ts#decrypt-a-token) (I know it's a small change, but it got me a bit confused at first).